### PR TITLE
Fix: Prevent division by zero error by setting null as fallback value for force16to9

### DIFF
--- a/Resources/Private/Fusion/Component/Video/Video.fusion
+++ b/Resources/Private/Fusion/Component/Video/Video.fusion
@@ -27,7 +27,7 @@ prototype(Jonnitto.PrettyEmbedVideoPlatforms:Component.Video) < prototype(Neos.F
 
     // If true, this get only a value if ratio is not set
     force16to9 = ${this.configuration.defaults.force16to9}
-    force16to9.@process.setRatio = ${value ? (16 / 9) : false}
+    force16to9.@process.setRatio = ${value ? (16 / 9) : null}
 
     wrapper = ${Configuration.setting('Jonnitto.PrettyEmbedHelper.wrapper')}
 


### PR DESCRIPTION
The `force16to9` property is boolean, but if it was set to `false` on a video I kept getting a "Division by zero" error from Fusion. I think this is caused by the line `finalRatio = ${Jonnitto.PrettyEmbedHelper.paddingTop(this.ratio || this.force16to9)}` in `Component/Video/Video.fusion` as the `paddingTop`helper expects `float|integer|string` (and defaults to `null`) but no boolean value.