### PR TITLE
!!!FEATURE: Make Neos 9.0 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ preview images, lightbox feature, and advanced customization of embed options.
 | 2.\*    | >= 5.3      |     ✗      |
 | 3.\*    | >= 5.3      |     ✗      |
 | 6.\*    | >= 7.3      |     ✓      |
+| 7.\*    | >= 9.0      |     ✓      |
 
 > The version jump was made to have all packages from the PrettyEmbed series on the same number
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "jonnitto/prettyembedhelper": "^7.0 || dev-master"
+        "jonnitto/prettyembedhelper": "^9.0 || dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "jonnitto/prettyembedhelper": "^6.6 || dev-master"
+        "jonnitto/prettyembedhelper": "^7.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR will use the Neos 9 compatible version of Jonnitto.PrettyEmbedHelper as it is a breaking change we need to wait for the release of version 7.0.

https://github.com/jonnitto/Jonnitto.PrettyEmbedHelper/pull/33

